### PR TITLE
Removing multiline output of the toHuman

### DIFF
--- a/lib/calendar_time.dart
+++ b/lib/calendar_time.dart
@@ -180,7 +180,7 @@ class CalendarTime {
     final String day = dayFormat.format(dateLocal);
     final String fullDate = DateFormat.yMMMEd().format(dateLocal);
     final String fullTime = DateFormat.jm().format(dateLocal);
-    final String fullDateTime = "$fullDate\n$fullTime";
+    final String fullDateTime = "$fullDate $fullTime";
 
     if (isToday) {
       return 'Today at $time';

--- a/test/calendar_time_test.dart
+++ b/test/calendar_time_test.dart
@@ -7,6 +7,11 @@ void main() {
     expect(calendarTime.toHuman.contains('Today'), true);
   });
 
+  test('converts time to human value as a single line', () {
+    final calendarTime = CalendarTime(DateTime(2010, 10, 10));
+    expect(calendarTime.toHuman.contains("\n"), false);
+  });
+
   test('it should format a date', () {
     final calendarTime = CalendarTime(DateTime(2010, 1, 1));
     expect(calendarTime.format('dd/MM/yy'), "01/01/10");


### PR DESCRIPTION
The `toHuman` implementation splits the output into several lines in a certain case.
This behavior seems redundant because we have got `toHumanMultiLine` for this purpose.

This PR changes this behavior.